### PR TITLE
Added bake in version script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "dev": "vite",
-    "build": "vue-tsc && vite build",
+    "build": "node scripts/bakeInVersion.js && vue-tsc && vite build",
     "build:docs": "typedoc && concat-md --decrease-title-levels --start-title-level-at=2 docs_raw > README.md && node scripts/postProcessDocs.js",
     "preview": "vite preview",
     "lint": "eslint --ext .js,.vue,.ts src",

--- a/scripts/bakeInVersion.js
+++ b/scripts/bakeInVersion.js
@@ -1,0 +1,12 @@
+// bake the version from package.json into a generated module so the source
+// does not import package.json directly (keeps it out of the bundle/source maps)
+import { readFileSync, writeFileSync } from 'node:fs'
+
+const pkg = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8')
+)
+
+writeFileSync(
+  new URL('../src/version.ts', import.meta.url),
+  `export const VERSION = ${JSON.stringify(pkg.version)}\n`
+)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 import * as PiwikPRO from '@piwikpro/tracking-base-library'
 export * from '@piwikpro/tracking-base-library'
-import { version } from '../package.json'
+import { VERSION } from './version'
 import { Initialize, Miscellaneous } from '@piwikpro/tracking-base-library'
 
 const initialize: Initialize = (...args) => {
   if (typeof window !== 'undefined') {
-    Miscellaneous.setTrackingSourceProvider('vue', version)
+    Miscellaneous.setTrackingSourceProvider('vue', VERSION)
   }
 
   PiwikPRO.default.initialize(...args)

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,1 @@
+export const VERSION = "1.7.0"


### PR DESCRIPTION
This is a preparation PR before updating the vite to the newest version, without this change newest version of vite will include package.json in sources of .map files.
This change also makes including new version consistent across other -piwik-pro libraries