### PR TITLE
chore: bump tracking-base-library from 1.7.0 to 1.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Please explore the `./vue-piwik-pro-example` directory to get to know how to use
 
 - [Dimensions](#type-aliasesdimensionsmd)
 - [EcommerceOptions](#type-aliasesecommerceoptionsmd)
+- [GetInitScript](#type-aliasesgetinitscriptmd)
 - [Initialize](#type-aliasesinitializemd)
 - [InitOptions](#type-aliasesinitoptionsmd)
 - [PaymentInformation](#type-aliasespaymentinformationmd)
@@ -2146,6 +2147,27 @@ Please use the ecommerceOrder instead.
 Currency code in [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) format. If not provided, the currency set in app settings will be used instead.
 
 
+<a name="type-aliasesgetinitscriptmd"></a>
+
+
+***
+
+
+## GetInitScript
+
+> **GetInitScript** = (`params`) => `string`
+
+### Parameters
+
+| Parameter | Type |
+| ------ | ------ |
+| `params` | `GetInitScriptParams` |
+
+### Returns
+
+`string`
+
+
 <a name="type-aliasesinitoptionsmd"></a>
 
 
@@ -2312,21 +2334,7 @@ Defaults to 'dataLayer'
 
 #### getInitScript
 
-> **getInitScript**: (`__namedParameters`) => `string`
-
-##### Parameters
-
-| Parameter | Type |
-| ------ | ------ |
-| `__namedParameters` | \{ `containerId`: `string`; `containerUrl`: `string`; `dataLayerName?`: `string`; `nonceValue?`: `string`; \} |
-| `__namedParameters.containerId` | `string` |
-| `__namedParameters.containerUrl` | `string` |
-| `__namedParameters.dataLayerName?` | `string` |
-| `__namedParameters.nonceValue?` | `string` |
-
-##### Returns
-
-`string`
+> **getInitScript**: [`GetInitScript`](#type-aliasesgetinitscriptmd) = `PiwikPro.getInitScript`
 
 #### initialize
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
-        "@piwikpro/tracking-base-library": "^1.7.0"
+        "@piwikpro/tracking-base-library": "^1.7.1"
       },
       "devDependencies": {
         "@babel/core": "^7.23.9",
@@ -2572,9 +2572,9 @@
       }
     },
     "node_modules/@piwikpro/tracking-base-library": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@piwikpro/tracking-base-library/-/tracking-base-library-1.7.0.tgz",
-      "integrity": "sha512-0u5YTcYO2As9T6ZFuJn0da6VYWz0sVYFFujkwiD8fz0o+Jjvl8r8Fk7rM2/ifLs03bqBOYe8MZRCjDKHWQzaiQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@piwikpro/tracking-base-library/-/tracking-base-library-1.7.1.tgz",
+      "integrity": "sha512-vDV8NZ7rYTlhKBHMHL880QqPOPzrXSurZn0sfhodqwGa9v7tmqLJe0IaG2Su1fOtlQm5pb2zobm8ngar45AKmQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
     "plugin"
   ],
   "dependencies": {
-    "@piwikpro/tracking-base-library": "^1.7.0"
+    "@piwikpro/tracking-base-library": "^1.7.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import * as PiwikPRO from '@piwikpro/tracking-base-library'
+import PiwikPro from '@piwikpro/tracking-base-library'
 export * from '@piwikpro/tracking-base-library'
 import { VERSION } from './version'
 import { Initialize, Miscellaneous } from '@piwikpro/tracking-base-library'
@@ -8,11 +8,10 @@ const initialize: Initialize = (...args) => {
     Miscellaneous.setTrackingSourceProvider('vue', VERSION)
   }
 
-  PiwikPRO.default.initialize(...args)
+  PiwikPro.initialize(...args)
 }
 
 export default {
-  ...PiwikPRO.default,
   initialize,
-  // fixes some 'The inferred type of 'default' cannot be named without a reference to ...' error
-} as typeof PiwikPRO.default
+  getInitScript: PiwikPro.getInitScript,
+}


### PR DESCRIPTION
Bump tracking-base-library from 1.7.0 to 1.7.1. It allows to remove the  type casting.