### PR TITLE
ci: added pr title lint shared action

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,38 +1,21 @@
 name: Lint PR Title
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited
       - synchronize
       - reopened
+      - ready_for_review
 
 permissions:
-  pull-requests: read
+  contents: read
 
 jobs:
-  validate:
-    name: Validate PR title
+  lint:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    if: github.event.pull_request.draft == false
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          types: |
-            feat
-            fix
-            perf
-            refactor
-            docs
-            test
-            build
-            ci
-            chore
-            revert
-          requireScope: false
-          subjectPattern: ^(?![A-Z]).+$
-          subjectPatternError: |
-            The subject "{subject}" should start with a lowercase character.
+      - uses: PiwikPRO/actions/pr-title@master


### PR DESCRIPTION
Replacing a third party github action with a custom script that validates PR title according to the conventional commits standard.